### PR TITLE
fix(atomi_release): incorrect convention docs in atomi_release

### DIFF
--- a/atomi_release.yaml
+++ b/atomi_release.yaml
@@ -7,7 +7,7 @@ conventionMarkdown:
     id: commit-conventions
     title: Commit Conventions
     ---
-    var__convention_docs__
+    var___convention_docs___
 keywords:
   - BREAKING CHANGE
   - BREAKING CHANGES


### PR DESCRIPTION
- corrected variable name from 'var__convention_docs__' to 'var___convention_docs___'

the change was made to adhere to the correct naming convention for variables in the documentation.