### PR TITLE
Deep Source

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,7 +1,10 @@
 version = 1
 
+test_patterns = ["UnitTest/**/*.cs"]
+
 [[analyzers]]
 name = "csharp"
 
 [[analyzers]]
 name = "shell"
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   precommit:
-    name: Pre-commit Check
+    name: Pre-Commit
     runs-on:
       - nscloud-ubuntu-22.04-amd64-4x8-with-cache
       - nscloud-cache-size-50gb

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Chsarpier
 dotCover.Output/
 dotCover.Output.*
 *.*.DotSettings.user
+.vscode/

--- a/Lithium/AsyncResultCollectionExtensions.cs
+++ b/Lithium/AsyncResultCollectionExtensions.cs
@@ -474,7 +474,6 @@ public static class AsyncResultCollectionExtensions
     /// <param name="Then">The function to execute if predicate returns True</param>
     /// <param name="Else">The function to execute if predicate returns False</param>
     /// <returns>Collection after executing function on each element</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static IEnumerable<Task<Result<TResult>>> IfEach<TSucc, TResult>(
         this IEnumerable<Task<Result<TSucc>>> results,
         Func<TSucc, Result<bool>> predicate,
@@ -494,7 +493,6 @@ public static class AsyncResultCollectionExtensions
     /// <param name="Then">The async function to execute if predicate returns True</param>
     /// <param name="Else">The async function to execute if predicate returns False</param>
     /// <returns>Collection after executing function on each element</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static IEnumerable<Task<Result<TResult>>> IfAwaitEach<TSucc, TResult>(
         this IEnumerable<Task<Result<TSucc>>> results,
         Func<TSucc, Task<Result<bool>>> predicate,
@@ -514,7 +512,6 @@ public static class AsyncResultCollectionExtensions
     /// <typeparam name="TSucc">Input type</typeparam>
     /// <typeparam name="TResult">Return type</typeparam>
     /// <returns>Collection after executing function on each element</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static IEnumerable<Task<TResult>> MatchAwaitEach<TSucc, TResult>(
         this IEnumerable<Task<Result<TSucc>>> results,
         Func<TSucc, Task<TResult>> Success,
@@ -532,7 +529,6 @@ public static class AsyncResultCollectionExtensions
     /// <param name="Failure">The function to execute if Result is Error</param>
     /// <typeparam name="TSucc">Input type</typeparam>
     /// <returns>Collection after executing function on each element</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static IEnumerable<Task> MatchAwaitEach<TSucc>(
         this IEnumerable<Task<Result<TSucc>>> results,
         Func<TSucc, Task> Success,
@@ -551,7 +547,6 @@ public static class AsyncResultCollectionExtensions
     /// <typeparam name="TSucc">Input type</typeparam>
     /// <typeparam name="TResult">Return type</typeparam>
     /// <returns>Collection after executing function on each element</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static IEnumerable<Task<TResult>> MatchEach<TSucc, TResult>(
         this IEnumerable<Task<Result<TSucc>>> results,
         Func<TSucc, TResult> Success,
@@ -569,7 +564,6 @@ public static class AsyncResultCollectionExtensions
     /// <param name="Failure">The function to execute if Result is Error</param>
     /// <typeparam name="TSucc">Input type</typeparam>
     /// <returns>Collection after executing function on each element</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static IEnumerable<Task> MatchEach<TSucc>(
         this IEnumerable<Task<Result<TSucc>>> results,
         Action<TSucc> Success,

--- a/Lithium/AsyncResultExtensions.cs
+++ b/Lithium/AsyncResultExtensions.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace CarboxylicLithium;
 
-#pragma warning disable CS1998
 /// <summary>
 /// Static class for extensions methods manipulating Async Results
 /// </summary>
@@ -34,7 +33,6 @@ public static class AsyncResultExtensions
     /// <typeparam name="TInput">Type of the input Result</typeparam>
     /// <typeparam name="T">Return type of the function</typeparam>
     /// <returns>Object of type T</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static async Task<T> MatchAwait<TInput, T>(
         this Task<Result<TInput>> res,
         Func<TInput, Task<T>> Success,
@@ -54,7 +52,6 @@ public static class AsyncResultExtensions
     /// <param name="Success">Async function to execute on Success</param>
     /// <param name="Failure">Async function to execute on Failure</param>
     /// <typeparam name="TInput">Type of the input Result</typeparam>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static async Task MatchAwait<TInput>(
         this Task<Result<TInput>> res,
         Func<TInput, Task> Success,
@@ -76,7 +73,6 @@ public static class AsyncResultExtensions
     /// <typeparam name="TInput">Type of the input Result</typeparam>
     /// <typeparam name="T">Return type of the function</typeparam>
     /// <returns>Object of type T</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static async Task<T> Match<TInput, T>(
         this Task<Result<TInput>> res,
         Func<TInput, T> Success,
@@ -95,7 +91,6 @@ public static class AsyncResultExtensions
     /// <param name="Success">Function to execute on Success</param>
     /// <param name="Failure">Function to execute on Failure</param>
     /// <typeparam name="TInput">Type of the input Result</typeparam>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static async Task Match<TInput>(
         this Task<Result<TInput>> res,
         Action<TInput> Success,
@@ -437,7 +432,6 @@ public static class AsyncResultExtensions
     /// <param name="Then">The async function to execute if predicate returns True</param>
     /// <param name="Else">The async function to execute if predicate returns False</param>
     /// <returns>Either the Success, or a Failure</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static Task<Result<TResult>> IfAwait<TSucc, TResult>(
         this Task<Result<TSucc>> res,
         Func<TSucc, Task<Result<bool>>> predicate,
@@ -461,7 +455,6 @@ public static class AsyncResultExtensions
     /// <param name="Then">The function to execute if predicate returns True</param>
     /// <param name="Else">The function to execute if predicate returns False</param>
     /// <returns>Either the Success, or a Failure</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static async Task<Result<TResult>> If<TSucc, TResult>(
         this Task<Result<TSucc>> res,
         Func<TSucc, Result<bool>> predicate,

--- a/Lithium/Lithium.csproj
+++ b/Lithium/Lithium.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>CarboxylicLithium</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Lithium/Result.cs
+++ b/Lithium/Result.cs
@@ -335,7 +335,6 @@ public readonly struct Result<TSucc>
     /// <param name="Then">The function to execute if predicate returns True</param>
     /// <param name="Else">The function to execute if predicate returns False</param>
     /// <returns>Either the Success, or a Failure</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public Result<TResult> If<TResult>(
         Func<TSucc, Result<bool>> predicate,
         Func<TSucc, Result<TResult>> Then,
@@ -354,7 +353,7 @@ public readonly struct Result<TSucc>
     /// <returns>Mapped Failure if Result is Failure</returns>
     public Result<TSucc> MapFailure(Func<Exception, Exception> mapper)
     {
-        return Match<Result<TSucc>>(s => s, e => mapper(e));
+        return Match<Result<TSucc>>(s => s, e => (Result<TSucc>)mapper(e));
     }
 
     /// <summary>
@@ -366,7 +365,6 @@ public readonly struct Result<TSucc>
     /// <param name="Failure">Function to execute on Failure</param>
     /// <typeparam name="T">Return type of the function</typeparam>
     /// <returns>Object of type T</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public T Match<T>(Func<TSucc, T> Success, Func<Exception, T> Failure)
     {
         return _isSuccess ? Success(_value!) : Failure(_exception!);
@@ -380,7 +378,6 @@ public readonly struct Result<TSucc>
     /// <param name="Success">Function to execute on Success</param>
     /// <param name="Failure">Function to execute on Failure</param>
     /// <returns>Returns Unit, denoting null return (void function)</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public void Match(Action<TSucc> Success, Action<Exception> Failure)
     {
         if (_isSuccess)

--- a/Lithium/ResultCollectionExtensions.cs
+++ b/Lithium/ResultCollectionExtensions.cs
@@ -274,7 +274,6 @@ public static class ResultCollectionExtensions
     /// <param name="Then">The function to execute if predicate returns True</param>
     /// <param name="Else">The function to execute if predicate returns False</param>
     /// <returns>Collection after executing function on each element</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static IEnumerable<Result<TResult>> IfEach<TSucc, TResult>(
         this IEnumerable<Result<TSucc>> results,
         Func<TSucc, Result<bool>> predicate,
@@ -294,7 +293,6 @@ public static class ResultCollectionExtensions
     /// <typeparam name="TSucc">Input type</typeparam>
     /// <typeparam name="TResult">Return type</typeparam>
     /// <returns>Collection after executing function on each element</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static IEnumerable<TResult> MatchEach<TSucc, TResult>(
         this IEnumerable<Result<TSucc>> results,
         Func<TSucc, TResult> Success,
@@ -312,7 +310,6 @@ public static class ResultCollectionExtensions
     /// <param name="Failure">The function to execute if Result is Error</param>
     /// <typeparam name="TSucc">Input type</typeparam>
     /// <returns>Collection after executing function on each element</returns>
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
     public static void MatchEach<TSucc>(
         this IEnumerable<Result<TSucc>> results,
         Action<TSucc> Success,

--- a/Lithium/Utils.cs
+++ b/Lithium/Utils.cs
@@ -43,7 +43,7 @@ public static class Utils
     /// <param name="o">Input object</param>
     /// <typeparam name="T">Type to cast to</typeparam>
     /// <returns>Result holding either input object cast to T or InvalidCastException.</returns>
-    public static Result<T> As<T>(this object o)
+    public static Result<T> As<T>(this object o) // skipcq: CS-R1112
     {
         if (o is T t)
             return t;

--- a/LithiumTestHelper/LithiumTestHelper.csproj
+++ b/LithiumTestHelper/LithiumTestHelper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>CarboxylicLithiumTestHelper</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/README.MD
+++ b/README.MD
@@ -1,9 +1,6 @@
 # Result
 
-[![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=AtomiCloud_carboxylic.lithium&metric=alert_status)](https://sonarcloud.io/dashboard?id=AtomiCloud_carboxylic.lithium )
-[![SonarCloud Coverage](https://sonarcloud.io/api/project_badges/measure?project=AtomiCloud_carboxylic.lithium&metric=coverage)](https://sonarcloud.io/component_measures/metric/coverage/list?id=AtomiCloud_carboxylic.lithium)
-[![SonarCloud Bugs](https://sonarcloud.io/api/project_badges/measure?project=AtomiCloud_carboxylic.lithium&metric=bugs)](https://sonarcloud.io/component_measures/metric/reliability_rating/list?id=AtomiCloud_carboxylic.lithium)
-[![SonarCloud Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=AtomiCloud_carboxylic.lithium&metric=vulnerabilities)](https://sonarcloud.io/component_measures/metric/security_rating/list?id=AtomiCloud_carboxylic.lithium)
+[![DeepSource](https://app.deepsource.com/gh/AtomiCloud/carboxylic.lithium.svg/?label=active+issues)](https://app.deepsource.com/gh/AtomiCloud/carboxylic.lithium/)
 [![GitHub Release Date](https://img.shields.io/github/release-date/AtomiCloud/carboxylic.lithium)](https://github.com/AtomiCloud/carboxylic.lithium/releases)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/AtomiCloud/carboxylic.lithium)](https://github.com/AtomiCloud/carboxylic.lithium/commits/main)
 ![GitHub commits since latest release](https://img.shields.io/github/commits-since/AtomiCloud/carboxylic.lithium/latest)

--- a/UnitTest/AsyncResultCollectionExtensionsTests.cs
+++ b/UnitTest/AsyncResultCollectionExtensionsTests.cs
@@ -487,10 +487,7 @@ public class AsyncResultCollectionExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            _ = await collection.Get();
-        };
+        var act = async () => await collection.Get();
 
         // Assert
         await act.Should().ThrowAsync<AggregateException>("there were failures in the collection.");
@@ -1636,7 +1633,7 @@ public class AsyncResultCollectionExtensionsTests
 
                     return (Result<string>)"SafeValue";
                 },
-                new InvalidOperationException($"Func physically threw for i=10")
+                new InvalidOperationException("Func physically threw for i=10")
             );
         }
     }
@@ -2033,10 +2030,7 @@ public class AsyncResultCollectionExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await Task.WhenAll(inputs.DoEach(doType, action, Errors.MapNone));
-        };
+        var act = async () => await Task.WhenAll(inputs.DoEach(doType, action, Errors.MapNone));
 
         // Assert
         await act.Should().ThrowAsync<Exception>().WithMessage(expected.Message);

--- a/UnitTest/AsyncResultExtensionsTests.cs
+++ b/UnitTest/AsyncResultExtensionsTests.cs
@@ -739,10 +739,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.DoAwait(doType, action, Errors.MapNone);
-        };
+        var act = async () => await subject.DoAwait(doType, action, Errors.MapNone);
 
         // Assert
         // Expect the original exception to propagate
@@ -902,10 +899,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.DoAwait(doType, asyncFunc, Errors.MapNone);
-        };
+        var act = async () => await subject.DoAwait(doType, asyncFunc, Errors.MapNone);
 
         // Assert
         await act.Should()
@@ -1052,10 +1046,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.ThenAwait(asyncFunc);
-        };
+        var act = async () => await subject.ThenAwait(asyncFunc);
 
         // Assert
         await act.Should()
@@ -1608,10 +1599,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.Then(function);
-        };
+        var act = async () => await subject.Then(function);
 
         // Assert
         await act.Should()
@@ -1748,10 +1736,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.Then(function, Errors.MapNone);
-        };
+        var act = async () => await subject.Then(function, Errors.MapNone);
 
         // Assert
         await act.Should()
@@ -1893,10 +1878,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.AssertAwait(assertion);
-        };
+        var act = async () => await subject.AssertAwait(assertion);
 
         // Assert
         await act.Should()
@@ -2078,10 +2060,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.AssertAwait(assertion, Errors.MapNone);
-        };
+        var act = async () => await subject.AssertAwait(assertion, Errors.MapNone);
 
         // Assert
         await act.Should()
@@ -2369,10 +2348,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.Assert(assertion, Errors.MapNone);
-        };
+        var act = async () => await subject.Assert(assertion, Errors.MapNone);
 
         // Assert
         await act.Should()
@@ -2614,10 +2590,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.IfAwait(predicate, Then, Else);
-        };
+        var act = async () => await subject.IfAwait(predicate, Then, Else);
 
         // Assert
         await act.Should()
@@ -2736,10 +2709,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.IfAwait(predicate, Then, Else);
-        };
+        var act = async () => await subject.IfAwait(predicate, Then, Else);
 
         // Assert
         await act.Should()
@@ -2858,10 +2828,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.IfAwait(predicate, Then, Else);
-        };
+        var act = async () => await subject.IfAwait(predicate, Then, Else);
 
         // Assert
         await act.Should()
@@ -3088,10 +3055,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.If(predicate, Then, Else);
-        };
+        var act = async () => await subject.If(predicate, Then, Else);
 
         // Assert
         await act.Should()
@@ -3196,10 +3160,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.If(predicate, Then, Else);
-        };
+        var act = async () => await subject.If(predicate, Then, Else);
 
         // Assert
         await act.Should()
@@ -3304,10 +3265,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.If(predicate, Then, Else);
-        };
+        var act = async () => await subject.If(predicate, Then, Else);
 
         // Assert
         await act.Should()
@@ -3427,10 +3385,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.Do(doType, transformFunc);
-        };
+        var act = async () => await subject.Do(doType, transformFunc);
 
         // Assert
         await act.Should()
@@ -3566,10 +3521,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.Do(doType, function, mapException);
-        };
+        var act = async () => await subject.Do(doType, function, mapException);
 
         // Assert
         await act.Should()
@@ -3714,10 +3666,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.Do(doType, action, mapException);
-        };
+        var act = async () => await subject.Do(doType, action, mapException);
 
         // Assert
         await act.Should()
@@ -3856,10 +3805,7 @@ public class AsyncResultExtensionsTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            await subject.Then(function, mapException);
-        };
+        var act = async () => await subject.Then(function, mapException);
 
         // Assert
         await act.Should()

--- a/UnitTest/AsyncResultTest.cs
+++ b/UnitTest/AsyncResultTest.cs
@@ -227,10 +227,7 @@ public class AsyncResultTests
         var asyncResultFunc = throwingFunc.ToAsyncResultFunc(Errors.MapNone);
 
         // Act
-        var act = async () =>
-        {
-            _ = await asyncResultFunc(123);
-        };
+        var act = async () => await asyncResultFunc(123);
 
         // Assert - expecting unwrapped exception
         await act.Should().ThrowAsync<FormatException>().WithMessage("Should be rethrown");
@@ -363,10 +360,7 @@ public class AsyncResultTests
         var asyncResultFunc = throwingFunc.ToAsyncResultFunc(Errors.MapNone);
 
         // Act
-        var act = async () =>
-        {
-            _ = await asyncResultFunc(5);
-        };
+        var act = async () => _ = await asyncResultFunc(5);
 
         // Assert
         await act.Should()
@@ -468,10 +462,7 @@ public class AsyncResultTests
         var asyncResultFunc = throwingFunc.ToAsyncResultFunc(Errors.MapNone);
 
         // Act
-        var act = async () =>
-        {
-            _ = await asyncResultFunc(123);
-        };
+        var act = async () => await asyncResultFunc(123);
 
         // Assert
         await act.Should().ThrowAsync<FormatException>().WithMessage("Should be rethrown");
@@ -983,10 +974,7 @@ public class AsyncResultTests
     )
     {
         // Act
-        var act = async () =>
-        {
-            _ = await input.Get();
-        };
+        var act = async () => await input.Get();
 
         // Assert
         await act.Should()

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/nix/env.nix
+++ b/nix/env.nix
@@ -24,10 +24,6 @@ with packages;
     sg
   ];
 
-  sonar = [
-    jdk
-  ];
-
   releaser = [
     sg
   ];

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -18,8 +18,7 @@ let
       with pkgs-2411;
       {
 
-        dotnet = dotnet-sdk_9;
-        jdk = zulu17;
+        dotnet = dotnet-sdk;
 
         inherit
           xmlstarlet

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -9,10 +9,6 @@ with env;
     buildInputs = system ++ main ++ lint;
     inherit shellHook;
   };
-  sonar = pkgs.mkShell {
-    buildInputs = system ++ main ++ lint ++ sonar;
-    inherit shellHook;
-  };
   releaser = pkgs.mkShell {
     buildInputs = system ++ main ++ lint ++ releaser;
     inherit shellHook;


### PR DESCRIPTION
- changed job name from 'Pre-commit Check' to 'Pre-Commit'
- updated target framework from 'net9.0' to 'net8.0' in multiple project files
- added a comment to skip a specific lint check in Utils.cs

these changes address linting errors reported by deepsource, ensuring code quality and compliance with project standards.