### PR TITLE
fix(ci): use auth-bot for releaser

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - nscloud-git-mirror-1gb
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v1
+      - uses: AtomiCloud/actions.setup-nix@v2
       - uses: AtomiCloud/actions.cache-nuget@v1
 
       # pre commit
@@ -32,7 +32,7 @@ jobs:
       - nscloud-git-mirror-1gb
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v1
+      - uses: AtomiCloud/actions.setup-nix@v2
       - uses: AtomiCloud/actions.cache-nuget@v1
 
       # Test
@@ -52,7 +52,11 @@ jobs:
       - nscloud-git-mirror-1gb
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v1
+      - uses: AtomiCloud/actions.setup-nix@v2
+        with:
+          auth-bot-app-id: ${{ vars.AUTH_BOT_APP_ID }}
+          auth-bot-secret-key: ${{ secrets.AUTH_BOT_SECRET_KEY }}
+
       - uses: AtomiCloud/actions.cache-npm@v1
       - uses: AtomiCloud/actions.cache-nuget@v1
 

--- a/LithiumTestHelper/LithiumTestHelper.csproj
+++ b/LithiumTestHelper/LithiumTestHelper.csproj
@@ -16,9 +16,9 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <None Include="..\README.MD" Pack="true" PackagePath="\"/>
-        <None Include="..\LICENSE" Pack="true" PackagePath="\"/>
-        <None Include="..\logo.png" Pack="true" PackagePath="\"/>
+        <None Include="..\README.MD" Pack="true" PackagePath="\" />
+        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
+        <None Include="..\logo.png" Pack="true" PackagePath="\" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
- updated setup-nix action from v1 to v2
- added auth-bot app id and secret key for authentication

the changes improve the CI workflow by using the latest version of the setup-nix action and integrating authentication for the releaser.